### PR TITLE
Put all RUNTIME_OUTPUT_DIRECTORY properties in the same place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,6 @@ target_include_directories(
     ${LIBTMX_INCLUDE_DIR}
     ${PICOLOG_INCLUDE_DIR})
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG   ${CMAKE_CURRENT_SOURCE_DIR}/demo)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_SOURCE_DIR}/demo)
-
 add_executable(
     demo
     ${demo_sources})
@@ -100,8 +97,9 @@ add_executable(
 set_target_properties(
     demo
     PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY
-    ${CMAKE_CURRENT_SOURCE_DIR}/demo)
+    RUNTIME_OUTPUT_DIRECTORY         ${CMAKE_CURRENT_SOURCE_DIR}/demo
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG   ${CMAKE_CURRENT_SOURCE_DIR}/demo
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_SOURCE_DIR}/demo)
 
 if(WIN32)
     set_target_properties(


### PR DESCRIPTION
I figured I should have kept these grouped together when I did this fix #15, It's just cleaner.